### PR TITLE
Add win-node-env package for setting NODE_ENV.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7342,6 +7342,12 @@
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
       "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
+    "win-node-env": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/win-node-env/-/win-node-env-0.4.0.tgz",
+      "integrity": "sha512-bf4TV/NOBEazlHJW/bOns7u2JaHe3f5bz8BYanm/xuqJ405NG9OK3VAI1Y2WvHJsAo4GMU8EYTHSh59Q3UfHvA==",
+      "optional": true
+    },
     "worker-farm": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-markdown": "^4.2.2"
+  },
+  "optionalDependencies": {
+    "win-node-env": "^0.4.0"
   }
 }


### PR DESCRIPTION
Previously when trying to run `npm run start` in Powershell I was getting an error that the "NODE_ENV..." wasn't recognised. This is because setting NODE_ENV isn't supported in the same way as on unix systems. 

To resolve this I have add an optional node package [Win-Node-Env](https://www.npmjs.com/package/win-node-env) which means that our start script is now 'cross platform' :)